### PR TITLE
Fix eval_single token argument

### DIFF
--- a/LLaVA-Chef/eval_single.py
+++ b/LLaVA-Chef/eval_single.py
@@ -53,7 +53,7 @@ print(f"📝 Prompt: {prompt}")
 input_ids = tokenizer_image_token(
     prompt_with_img,
     tokenizer,
-    IMAGE_TOKEN_INDEX=image_token_id,
+    image_token_index=image_token_id,
     return_tensors='pt'
 ).unsqueeze(0).to(device)
 


### PR DESCRIPTION
## Summary
- fix keyword argument for `tokenizer_image_token`

## Testing
- `python -m py_compile LLaVA-Chef/eval_single.py`

------
https://chatgpt.com/codex/tasks/task_e_685cab2c7e4c83338f9d650609a46690